### PR TITLE
feat(core): #19 Extend MockMvc based tests to identify the operation …

### DIFF
--- a/openapi-extender-resource-generator/src/main/java/org/rodnansol/openapi/extender/generator/ReportParams.java
+++ b/openapi-extender-resource-generator/src/main/java/org/rodnansol/openapi/extender/generator/ReportParams.java
@@ -1,5 +1,8 @@
 package org.rodnansol.openapi.extender.generator;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 /**
  * Class to be used as the report parameter.
  */
@@ -48,4 +51,18 @@ public class ReportParams implements ResourceGeneratorParams {
         return content;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReportParams that = (ReportParams) o;
+        return status == that.status && Objects.equals(operation, that.operation) && Objects.equals(name, that.name) && Objects.equals(contentType, that.contentType) && Arrays.equals(content, that.content) && Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(operation, name, status, contentType, description);
+        result = 31 * result + Arrays.hashCode(content);
+        return result;
+    }
 }

--- a/openapi-extender-spring-test/pom.xml
+++ b/openapi-extender-spring-test/pom.xml
@@ -18,8 +18,19 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.rodnansol</groupId>

--- a/openapi-extender-spring-test/pom.xml
+++ b/openapi-extender-spring-test/pom.xml
@@ -33,6 +33,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.rodnansol</groupId>
             <artifactId>openapi-extender-resource-generator</artifactId>
             <scope>compile</scope>
@@ -50,6 +55,36 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/ApiResponseDocumentReporter.java
+++ b/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/ApiResponseDocumentReporter.java
@@ -1,5 +1,6 @@
 package org.rodnansol.openapi.extender.spring;
 
+import io.swagger.v3.oas.annotations.Operation;
 import org.rodnansol.openapi.extender.generator.ApiResponseExampleFileOutputResourceGenerator;
 import org.rodnansol.openapi.extender.generator.ReportParams;
 import org.slf4j.Logger;
@@ -7,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultHandler;
+import org.springframework.web.method.HandlerMethod;
 
 /**
  * Result handler implementation that documents the response of the incoming MvcResult.
@@ -18,6 +20,14 @@ public class ApiResponseDocumentReporter implements ResultHandler {
     private final String operation;
     private final String name;
     private final String description;
+
+    public ApiResponseDocumentReporter() {
+        this(null, null, null, ApiResponseExampleFileOutputResourceGenerator.DEFAULT_OUTPUT_DIRECTORY);
+    }
+
+    public ApiResponseDocumentReporter(String name) {
+        this(null, name, null, ApiResponseExampleFileOutputResourceGenerator.DEFAULT_OUTPUT_DIRECTORY);
+    }
 
     public ApiResponseDocumentReporter(String operation, String name) {
         this(operation, name, null, ApiResponseExampleFileOutputResourceGenerator.DEFAULT_OUTPUT_DIRECTORY);
@@ -38,12 +48,37 @@ public class ApiResponseDocumentReporter implements ResultHandler {
     public void handle(MvcResult result) {
         try {
             MockHttpServletResponse response = result.getResponse();
-            ReportParams params = new ReportParams(operation, name, response.getStatus(), response.getContentType(), response.getContentAsByteArray());
+            String finalOperation = getOperationName(result);
+            String finalName = getFinalName(finalOperation, response);
+            ReportParams params = new ReportParams(finalOperation, finalName, response.getStatus(), response.getContentType(), response.getContentAsByteArray());
             params.setDescription(description);
             apiResponseExampleDocumenter.generateResources(params);
         } catch (Exception e) {
             throw new OpenApiExtenderResultHandlerException("Error during documenting response", e);
         }
+    }
+
+    private String getFinalName(String finalOperation, MockHttpServletResponse response) {
+        if (name != null) {
+            return name;
+        }
+        return finalOperation + "-" + response.getStatus();
+    }
+
+    private String getOperationName(MvcResult result) {
+        String finalOperation = null;
+        if (operation != null) {
+            finalOperation = operation;
+        } else {
+            if (result.getHandler() instanceof HandlerMethod) {
+                HandlerMethod handler = (HandlerMethod) result.getHandler();
+                if (handler != null && handler.getMethod() != null) {
+                    Operation operationAnnotation = handler.getMethod().getAnnotation(Operation.class);
+                    finalOperation = operationAnnotation != null && operationAnnotation.operationId() != null ? operationAnnotation.operationId() : handler.getMethod().getName();
+                }
+            }
+        }
+        return finalOperation;
     }
 
 }

--- a/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/ApiResponseDocumentReporter.java
+++ b/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/ApiResponseDocumentReporter.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultHandler;
+import org.springframework.util.StringUtils;
 import org.springframework.web.method.HandlerMethod;
 
 /**
@@ -74,7 +75,7 @@ public class ApiResponseDocumentReporter implements ResultHandler {
                 HandlerMethod handler = (HandlerMethod) result.getHandler();
                 if (handler != null && handler.getMethod() != null) {
                     Operation operationAnnotation = handler.getMethod().getAnnotation(Operation.class);
-                    finalOperation = operationAnnotation != null && operationAnnotation.operationId() != null ? operationAnnotation.operationId() : handler.getMethod().getName();
+                    finalOperation = operationAnnotation != null && StringUtils.hasText(operationAnnotation.operationId()) ? operationAnnotation.operationId() : handler.getMethod().getName();
                 }
             }
         }

--- a/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/ApiResponseDocumentReporter.java
+++ b/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/ApiResponseDocumentReporter.java
@@ -1,6 +1,5 @@
 package org.rodnansol.openapi.extender.spring;
 
-import io.swagger.v3.oas.annotations.Operation;
 import org.rodnansol.openapi.extender.generator.ApiResponseExampleFileOutputResourceGenerator;
 import org.rodnansol.openapi.extender.generator.ReportParams;
 import org.slf4j.Logger;
@@ -8,8 +7,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultHandler;
-import org.springframework.util.StringUtils;
-import org.springframework.web.method.HandlerMethod;
 
 /**
  * Result handler implementation that documents the response of the incoming MvcResult.

--- a/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/MockMvcOpenApiDocumentation.java
+++ b/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/MockMvcOpenApiDocumentation.java
@@ -11,6 +11,26 @@ public final class MockMvcOpenApiDocumentation {
     /**
      * Creates an {@link ApiResponseDocumentReporter} with the incoming operation and description.
      *
+     * @param name name/key of the example.
+     * @return {@link ApiResponseDocumentReporter} instance.
+     */
+    public static ApiResponseDocumentReporter documentResponse() {
+        return new ApiResponseDocumentReporter();
+    }
+
+    /**
+     * Creates an {@link ApiResponseDocumentReporter} with the incoming operation and description.
+     *
+     * @param name name/key of the example.
+     * @return {@link ApiResponseDocumentReporter} instance.
+     */
+    public static ApiResponseDocumentReporter documentResponse(String name) {
+        return new ApiResponseDocumentReporter(name);
+    }
+
+    /**
+     * Creates an {@link ApiResponseDocumentReporter} with the incoming operation and description.
+     *
      * @param operation operation's name.
      * @param name      name/key of the example.
      * @return {@link ApiResponseDocumentReporter} instance.
@@ -42,6 +62,25 @@ public final class MockMvcOpenApiDocumentation {
      */
     public static ApiResponseDocumentReporter documentResponse(String operation, String name, String description, String outputDirectory) {
         return new ApiResponseDocumentReporter(operation, name, description, outputDirectory);
+    }
+
+    /**
+     * Creates an {@link RequestBodyDocumentReporter} with the incoming operation and description.
+     *
+     * @return {@link RequestBodyDocumentReporter} instance.
+     */
+    public static RequestBodyDocumentReporter documentRequest() {
+        return new RequestBodyDocumentReporter();
+    }
+
+    /**
+     * Creates an {@link RequestBodyDocumentReporter} with the incoming operation and description.
+     *
+     * @param name name/key of the example.
+     * @return {@link RequestBodyDocumentReporter} instance.
+     */
+    public static RequestBodyDocumentReporter documentRequest(String name) {
+        return new RequestBodyDocumentReporter(name);
     }
 
     /**

--- a/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/MockMvcOpenApiDocumentation.java
+++ b/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/MockMvcOpenApiDocumentation.java
@@ -11,7 +11,6 @@ public final class MockMvcOpenApiDocumentation {
     /**
      * Creates an {@link ApiResponseDocumentReporter} with the incoming operation and description.
      *
-     * @param name name/key of the example.
      * @return {@link ApiResponseDocumentReporter} instance.
      */
     public static ApiResponseDocumentReporter documentResponse() {

--- a/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/MvcResultReader.java
+++ b/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/MvcResultReader.java
@@ -1,0 +1,43 @@
+package org.rodnansol.openapi.extender.spring;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.util.StringUtils;
+import org.springframework.web.method.HandlerMethod;
+
+/**
+ * Class dealing with operations based on the {@link MvcResult} interface instances.
+ */
+class MvcResultReader {
+
+    private MvcResultReader() {
+    }
+
+    /**
+     * Calculates the final operation name based on the incoming parameters.
+     * <p>
+     * If the operation parameter is given and not null it will be returned.
+     * <p>
+     * If not and the MvcResult is given, then it will try to read the {@link Operation} annotation's {@link Operation#operationId()} attribute, if it is null it will return the name of the handler method.
+     *
+     * @param operation operation's name.
+     * @param result    {@link MvcResult} instance.
+     * @return final operation name.
+     */
+    public static String getOperationName(final String operation, final MvcResult result) {
+        String finalOperation = null;
+        if (operation != null) {
+            finalOperation = operation;
+        } else {
+            if (result.getHandler() instanceof HandlerMethod) {
+                HandlerMethod handler = (HandlerMethod) result.getHandler();
+                if (handler != null && handler.getMethod() != null) {
+                    Operation operationAnnotation = handler.getMethodAnnotation(Operation.class);
+                    finalOperation = operationAnnotation != null && StringUtils.hasText(operationAnnotation.operationId()) ? operationAnnotation.operationId() : handler.getMethod().getName();
+                }
+            }
+        }
+        return finalOperation;
+    }
+
+}

--- a/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/RequestBodyDocumentReporter.java
+++ b/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/RequestBodyDocumentReporter.java
@@ -1,6 +1,5 @@
 package org.rodnansol.openapi.extender.spring;
 
-import io.swagger.v3.oas.annotations.Operation;
 import org.rodnansol.openapi.extender.generator.ReportParams;
 import org.rodnansol.openapi.extender.generator.RequestBodyExampleFileOutputResourceGenerator;
 import org.slf4j.Logger;
@@ -9,8 +8,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultHandler;
-import org.springframework.util.StringUtils;
-import org.springframework.web.method.HandlerMethod;
 
 /**
  * Result handler implementation that documents the request of the incoming MvcResult.

--- a/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/RequestBodyDocumentReporter.java
+++ b/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/RequestBodyDocumentReporter.java
@@ -52,7 +52,7 @@ public class RequestBodyDocumentReporter implements ResultHandler {
         try {
             MockHttpServletResponse response = result.getResponse();
             MockHttpServletRequest request = result.getRequest();
-            String finalOperation = getOperationName(result);
+            String finalOperation = MvcResultReader.getOperationName(operation, result);
             String finalName = getFinalName(finalOperation, response);
             ReportParams params = new ReportParams(finalOperation, finalName, response.getStatus(), request.getContentType(), request.getContentAsByteArray());
             params.setDescription(description);
@@ -67,22 +67,6 @@ public class RequestBodyDocumentReporter implements ResultHandler {
             return name;
         }
         return finalOperation + "-" + response.getStatus();
-    }
-
-    private String getOperationName(MvcResult result) {
-        String finalOperation = null;
-        if (operation != null) {
-            finalOperation = operation;
-        } else {
-            if (result.getHandler() instanceof HandlerMethod) {
-                HandlerMethod handler = (HandlerMethod) result.getHandler();
-                if (handler != null && handler.getMethod() != null) {
-                    Operation operationAnnotation = handler.getMethod().getAnnotation(Operation.class);
-                    finalOperation = operationAnnotation != null && StringUtils.hasText(operationAnnotation.operationId()) ? operationAnnotation.operationId() : handler.getMethod().getName();
-                }
-            }
-        }
-        return finalOperation;
     }
 
 }

--- a/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/RequestBodyDocumentReporter.java
+++ b/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/RequestBodyDocumentReporter.java
@@ -9,6 +9,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultHandler;
+import org.springframework.util.StringUtils;
 import org.springframework.web.method.HandlerMethod;
 
 /**
@@ -77,7 +78,7 @@ public class RequestBodyDocumentReporter implements ResultHandler {
                 HandlerMethod handler = (HandlerMethod) result.getHandler();
                 if (handler != null && handler.getMethod() != null) {
                     Operation operationAnnotation = handler.getMethod().getAnnotation(Operation.class);
-                    finalOperation = operationAnnotation != null && operationAnnotation.operationId() != null ? operationAnnotation.operationId() : handler.getMethod().getName();
+                    finalOperation = operationAnnotation != null && StringUtils.hasText(operationAnnotation.operationId()) ? operationAnnotation.operationId() : handler.getMethod().getName();
                 }
             }
         }

--- a/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/RequestBodyDocumentReporter.java
+++ b/openapi-extender-spring-test/src/main/java/org/rodnansol/openapi/extender/spring/RequestBodyDocumentReporter.java
@@ -1,5 +1,6 @@
 package org.rodnansol.openapi.extender.spring;
 
+import io.swagger.v3.oas.annotations.Operation;
 import org.rodnansol.openapi.extender.generator.ReportParams;
 import org.rodnansol.openapi.extender.generator.RequestBodyExampleFileOutputResourceGenerator;
 import org.slf4j.Logger;
@@ -8,6 +9,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultHandler;
+import org.springframework.web.method.HandlerMethod;
 
 /**
  * Result handler implementation that documents the request of the incoming MvcResult.
@@ -19,6 +21,14 @@ public class RequestBodyDocumentReporter implements ResultHandler {
     private final String operation;
     private final String name;
     private final String description;
+
+    public RequestBodyDocumentReporter() {
+        this(null, null, null, RequestBodyExampleFileOutputResourceGenerator.DEFAULT_OUTPUT_DIRECTORY);
+    }
+
+    public RequestBodyDocumentReporter(String name) {
+        this(null, name, null, RequestBodyExampleFileOutputResourceGenerator.DEFAULT_OUTPUT_DIRECTORY);
+    }
 
     public RequestBodyDocumentReporter(String operation, String name) {
         this(operation, name, null, RequestBodyExampleFileOutputResourceGenerator.DEFAULT_OUTPUT_DIRECTORY);
@@ -41,12 +51,37 @@ public class RequestBodyDocumentReporter implements ResultHandler {
         try {
             MockHttpServletResponse response = result.getResponse();
             MockHttpServletRequest request = result.getRequest();
-            ReportParams params = new ReportParams(operation, name, response.getStatus(), request.getContentType(), request.getContentAsByteArray());
+            String finalOperation = getOperationName(result);
+            String finalName = getFinalName(finalOperation, response);
+            ReportParams params = new ReportParams(finalOperation, finalName, response.getStatus(), request.getContentType(), request.getContentAsByteArray());
             params.setDescription(description);
             requestBodyExampleDocumenter.generateResources(params);
         } catch (Exception e) {
             throw new OpenApiExtenderResultHandlerException("Error during documenting request body", e);
         }
+    }
+
+    private String getFinalName(String finalOperation, MockHttpServletResponse response) {
+        if (name != null) {
+            return name;
+        }
+        return finalOperation + "-" + response.getStatus();
+    }
+
+    private String getOperationName(MvcResult result) {
+        String finalOperation = null;
+        if (operation != null) {
+            finalOperation = operation;
+        } else {
+            if (result.getHandler() instanceof HandlerMethod) {
+                HandlerMethod handler = (HandlerMethod) result.getHandler();
+                if (handler != null && handler.getMethod() != null) {
+                    Operation operationAnnotation = handler.getMethod().getAnnotation(Operation.class);
+                    finalOperation = operationAnnotation != null && operationAnnotation.operationId() != null ? operationAnnotation.operationId() : handler.getMethod().getName();
+                }
+            }
+        }
+        return finalOperation;
     }
 
 }

--- a/openapi-extender-spring-test/src/test/java/org/rodnansol/openapi/extender/spring/ApiResponseDocumentReporterTest.java
+++ b/openapi-extender-spring-test/src/test/java/org/rodnansol/openapi/extender/spring/ApiResponseDocumentReporterTest.java
@@ -1,0 +1,47 @@
+package org.rodnansol.openapi.extender.spring;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.rodnansol.openapi.extender.generator.ApiResponseExampleFileOutputResourceGenerator;
+import org.rodnansol.openapi.extender.generator.ReportParams;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApiResponseDocumentReporterTest {
+
+    private static final String RESPONSE_CONTENT = "{\"name\":\"Hello OpenAPI Extender\"}";
+    @Mock
+    private ApiResponseExampleFileOutputResourceGenerator apiResponseExampleDocumenter;
+
+    @Mock
+    private MvcResult mvcResult;
+
+    @Mock
+    private MockHttpServletResponse response;
+
+    @Test
+    void testHandle_shouldCallGenerateResourcesWithGivenOperationName_whenOperationNameIsPreset() throws IOException {
+        // Given
+        when(response.getStatus()).thenReturn(200);
+        when(response.getContentType()).thenReturn(MediaType.APPLICATION_JSON_VALUE);
+        when(response.getContentAsByteArray()).thenReturn(RESPONSE_CONTENT.getBytes());
+        when(mvcResult.getResponse()).thenReturn(response);
+
+        // When
+        ApiResponseDocumentReporter underTest = new ApiResponseDocumentReporter(null, "test-operation-name", null, apiResponseExampleDocumenter);
+        underTest.handle(mvcResult);
+
+        // Then
+        ReportParams expectedReportParams = new ReportParams(null, "test-operation-name", 200, MediaType.APPLICATION_JSON_VALUE, RESPONSE_CONTENT.getBytes());
+        verify(apiResponseExampleDocumenter).generateResources(expectedReportParams);
+    }
+}

--- a/openapi-extender-spring-test/src/test/java/org/rodnansol/openapi/extender/spring/MvcResultReaderTest.java
+++ b/openapi-extender-spring-test/src/test/java/org/rodnansol/openapi/extender/spring/MvcResultReaderTest.java
@@ -1,0 +1,159 @@
+package org.rodnansol.openapi.extender.spring;
+
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MvcResultReaderTest {
+
+    @Mock
+    MvcResult result;
+    @Mock
+    HandlerMethod handlerMethod;
+    @Mock
+    Method method;
+    @Mock
+    MockOperation operation;
+
+    @Test
+    void getOperationName_shouldReturnOperationName_whenOperationIsNotNull() {
+        // Given
+
+        // When
+        String operationName = MvcResultReader.getOperationName("test-operation", null);
+
+        // Then
+        assertThat(operationName).isEqualTo("test-operation");
+    }
+
+    @Test
+    void getOperationName_shouldReturnNameOfTheHandlerMethod_whenNoOperationAnnotationIsSpecifiedAndOperationParamIsNull() {
+        // Given
+        when(method.getName()).thenReturn("testMethod");
+        when(handlerMethod.getMethod()).thenReturn(method);
+        when(result.getHandler()).thenReturn(handlerMethod);
+
+        // When
+        String operationName = MvcResultReader.getOperationName(null, result);
+
+        // Then
+        assertThat(operationName).isEqualTo("testMethod");
+    }
+
+    @Test
+    void getOperationName_shouldReturnTheValueOfTheOperationAnnotation_whenOperationAnnotationIsPresentAndOperationParamIsNull() {
+        // Given
+        when(operation.operationId()).thenReturn("testOperation");
+        when(handlerMethod.getMethodAnnotation(Operation.class)).thenReturn(operation);
+        when(handlerMethod.getMethod()).thenReturn(method);
+        when(result.getHandler()).thenReturn(handlerMethod);
+
+        // When
+        String operationName = MvcResultReader.getOperationName(null, result);
+
+        // Then
+        assertThat(operationName).isEqualTo("testOperation");
+    }
+
+    class MockOperation implements Operation {
+
+        @Override
+        public String method() {
+            return null;
+        }
+
+        @Override
+        public String[] tags() {
+            return new String[0];
+        }
+
+        @Override
+        public String summary() {
+            return null;
+        }
+
+        @Override
+        public String description() {
+            return null;
+        }
+
+        @Override
+        public RequestBody requestBody() {
+            return null;
+        }
+
+        @Override
+        public ExternalDocumentation externalDocs() {
+            return null;
+        }
+
+        @Override
+        public String operationId() {
+            return null;
+        }
+
+        @Override
+        public Parameter[] parameters() {
+            return new Parameter[0];
+        }
+
+        @Override
+        public ApiResponse[] responses() {
+            return new ApiResponse[0];
+        }
+
+        @Override
+        public boolean deprecated() {
+            return false;
+        }
+
+        @Override
+        public SecurityRequirement[] security() {
+            return new SecurityRequirement[0];
+        }
+
+        @Override
+        public Server[] servers() {
+            return new Server[0];
+        }
+
+        @Override
+        public Extension[] extensions() {
+            return new Extension[0];
+        }
+
+        @Override
+        public boolean hidden() {
+            return false;
+        }
+
+        @Override
+        public boolean ignoreJsonView() {
+            return false;
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return null;
+        }
+    }
+}

--- a/openapi-extender-spring-test/src/test/java/org/rodnansol/openapi/extender/spring/RequestBodyDocumentReporterTest.java
+++ b/openapi-extender-spring-test/src/test/java/org/rodnansol/openapi/extender/spring/RequestBodyDocumentReporterTest.java
@@ -1,0 +1,14 @@
+package org.rodnansol.openapi.extender.spring;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class RequestBodyDocumentReporterTest {
+
+
+    private RequestBodyDocumentReporter underTest;
+
+}

--- a/openapi-extender-spring-test/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/openapi-extender-spring-test/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/openapi-extender-swagger-core/pom.xml
+++ b/openapi-extender-swagger-core/pom.xml
@@ -20,6 +20,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-models</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -29,10 +30,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 
         <springdoc-openapi-ui.version>1.6.11</springdoc-openapi-ui.version>
         <spring-web.version>5.3.22</spring-web.version>
+        <spring-webmvc.version>5.3.22</spring-webmvc.version>
         <spring-test.version>5.3.22</spring-test.version>
         <jackson-core.version>2.13.4.1</jackson-core.version>
         <jackson-dataformat-xml.version>2.13.4</jackson-dataformat-xml.version>
@@ -49,8 +50,10 @@
         <junit-bom.version>5.9.0</junit-bom.version>
         <assertj-core.version>3.22.0</assertj-core.version>
         <rest-assured.version>5.2.0</rest-assured.version>
-        <mockito-core.version>4.6.1</mockito-core.version>
-        <mockito-junit-jupiter.version>4.6.1</mockito-junit-jupiter.version>
+        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
+        <mockito-core.version>4.9.0</mockito-core.version>
+        <mockito-junit-jupiter.version>4.9.0</mockito-junit-jupiter.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <junit-jupiter-params.version>5.8.1</junit-jupiter-params.version>
 
@@ -154,6 +157,12 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
                 <version>${spring-web.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${spring-webmvc.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <checkstyle.version>10.3.3</checkstyle.version>
 
         <springdoc-openapi-ui.version>1.6.11</springdoc-openapi-ui.version>
+        <spring-web.version>5.3.22</spring-web.version>
         <spring-test.version>5.3.22</spring-test.version>
         <jackson-core.version>2.13.4.1</jackson-core.version>
         <jackson-dataformat-xml.version>2.13.4</jackson-dataformat-xml.version>
@@ -43,6 +44,7 @@
         <slf4j-api.version>1.7.33</slf4j-api.version>
         <javax.servlet-api.version>4.0.0</javax.servlet-api.version>
         <swagger-models.version>2.0.0</swagger-models.version>
+        <swagger-annotations.version>2.0.0</swagger-annotations.version>
         <commons-io.version>2.11.0</commons-io.version>
         <junit-bom.version>5.9.0</junit-bom.version>
         <assertj-core.version>3.22.0</assertj-core.version>
@@ -131,6 +133,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>[${swagger-annotations.version},)</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
@@ -140,6 +148,12 @@
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-ui</artifactId>
                 <version>${springdoc-openapi-ui.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring-web.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/samples/spring-boot-openapi-with-test/src/main/java/com/example/springbootopenmapiwithtest/UserController.java
+++ b/samples/spring-boot-openapi-with-test/src/main/java/com/example/springbootopenmapiwithtest/UserController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 class UserController {
 
-    @GetMapping(path = "/user", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    @GetMapping(path = "/user", produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity getUser(@RequestParam(name = "id", required = false) String id) {
         if ("BAD".equals(id)) return ResponseEntity.badRequest().body(new ErrorResponse("Bad " + id, "Cause it went bad"));
         else if ("BAD2".equals(id)) return ResponseEntity.internalServerError().body(new ErrorResponse("Internal Server Error " + id, "Bad because internal"));

--- a/samples/spring-boot-openapi-with-test/src/test/java/com/example/springbootopenmapiwithtest/UserControllerTest.java
+++ b/samples/spring-boot-openapi-with-test/src/test/java/com/example/springbootopenmapiwithtest/UserControllerTest.java
@@ -29,7 +29,7 @@ class UserControllerTest {
         void getUser_isOk() throws Exception {
             mockMvc.perform(get("/user"))
                 .andExpect(status().isOk())
-                .andDo(result -> documentResponse("getUser", "Standard response").handle(result));
+                .andDo(result -> documentResponse().handle(result));
         }
 
         @Test
@@ -62,8 +62,8 @@ class UserControllerTest {
             UserController.UserRequest userRequest = new UserController.UserRequest("alex123", "password123", "password12", "Alex King");
             mockMvc.perform(post("/user").contentType(MediaType.APPLICATION_JSON).content(asJsonString(userRequest)))
                 .andExpect(status().isUnprocessableEntity())
-                .andDo(result -> documentResponse("postUser", "When passwords does not match").handle(result))
-                .andDo(result -> documentRequest("postUser", "Will throw error").handle(result));
+                .andDo(result -> documentResponse().handle(result))
+                .andDo(result -> documentRequest().handle(result));
         }
 
         @Test


### PR DESCRIPTION
…from the HandlerMethod if not specified

- MockMvc based tests can now identify the operation's name without defining it

Closes #19 